### PR TITLE
Fixes remindLaunches constantly triggering

### DIFF
--- a/lib/rate_my_app.dart
+++ b/lib/rate_my_app.dart
@@ -132,7 +132,7 @@ class RateMyAppDialog extends StatelessWidget {
                         rateMyApp.baseLaunchDate.add(Duration(
                           days: rateMyApp.remindDays,
                         ));
-                        rateMyApp.launches += rateMyApp.remindLaunches;
+                        rateMyApp.launches -= rateMyApp.remindLaunches;
                         rateMyApp.save().then((v) => Navigator.pop(context));
                       },
                     ),


### PR DESCRIPTION
We are not subtracting the remindLaunches to the total launches count, this results in reminder constantly triggering due to launches being far superior than minLaunches (since we are adding launches every time)