### PR TITLE
Color customization for rating stars

### DIFF
--- a/lib/dialogs.dart
+++ b/lib/dialogs.dart
@@ -84,16 +84,22 @@ class RateMyAppStarDialog extends StatefulWidget {
   /// The rating changed callback.
   final List<Widget> Function(int) _onRatingChanged;
 
+  // The fill color of the stars.
+  final Color starsFillColor;
+
+  // The border color for the stars.
+  final Color starsBorderColor;
+
   /// Creates a new rate my app star dialog.
-  RateMyAppStarDialog(this._title, this._message, this._onRatingChanged);
+  RateMyAppStarDialog(this._title, this._message, this._onRatingChanged, {this.starsFillColor, this.starsBorderColor});
 
   @override
   State<StatefulWidget> createState() => RateMyAppStarDialogState();
 
   /// Opens the dialog.
-  static Future<void> openDialog(BuildContext context, String title, String message, List<Widget> Function(int) onRatingChanged) async => await showDialog(
+  static Future<void> openDialog(BuildContext context, String title, String message, List<Widget> Function(int) onRatingChanged, {Color starsFillColor, Color starsBorderColor}) async => await showDialog(
         context: context,
-        builder: (context) => RateMyAppStarDialog(title, message, onRatingChanged),
+        builder: (context) => RateMyAppStarDialog(title, message, onRatingChanged, starsFillColor: starsFillColor, starsBorderColor: starsBorderColor),
       );
 }
 
@@ -114,6 +120,8 @@ class RateMyAppStarDialogState extends State<RateMyAppStarDialog> {
             Padding(
               padding: EdgeInsets.only(top: 20),
               child: SmoothStarRating(
+                color: widget.starsFillColor,
+                borderColor: widget.starsBorderColor,
                 allowHalfRating: false,
                 onRatingChanged: (rating) {
                   setState(() {

--- a/lib/rate_my_app.dart
+++ b/lib/rate_my_app.dart
@@ -104,13 +104,16 @@ class RateMyApp {
     String message = 'You like this app ? Then take a little bit of your time to leave a rating :',
     @required List<Widget> Function(int) onRatingChanged,
     bool ignoreIOS = false,
+    Color starsFillColor,
+    Color starsBorderColor,
   }) async {
     if (!ignoreIOS && Platform.isIOS && await _CHANNEL.invokeMethod('canRequestReview')) {
       return _CHANNEL.invokeMethod('requestReview');
     }
 
     assert(onRatingChanged != null);
-    return RateMyAppStarDialog.openDialog(context, title, message, onRatingChanged);
+    return RateMyAppStarDialog.openDialog(
+        context, title, message, onRatingChanged, starsFillColor: starsFillColor, starsBorderColor: starsBorderColor);
   }
 
   /// Launches the corresponding store.


### PR DESCRIPTION
This PR adds color customization for the rating stars in the RateMyAppStarDialog.
The package consumer can now hand in a fill color and a border color for the stars when opening the dialog. The colors are then handed through to SmoothStarRating.